### PR TITLE
Add linter name

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ export const provideLinter = () => {
   let preset = require(presetConfig());
 
   return {
+    name: 'stylelint',
     grammarScopes: ['source.css'],
     scope: 'file',
     lintOnFly: true,


### PR DESCRIPTION
Specifies the linter name, allowing the `linter` package to display it if the user chooses to.
