### PR TITLE
Show notification on syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,16 @@ export const provideLinter = () => {
             };
           }));
 
-        }).catch(error => console.error(error));
+        }).catch(error => {
+          if (error.line && error.reason) {
+            atom.notifications.addWarning(`CSS Syntax Error`, {
+              detail: `${error.reason} on line ${error.line}`,
+              dismissable: true
+            });
+          }
+
+          console.error(error);
+        });
       });
     }
   };


### PR DESCRIPTION
Currently the stylelint linter will fail if it encounters a CSS syntax error.

While I realize this is a bit of a limitation with Stylelint since it errors on the first syntax error, I think it is a good idea to at least bubble this up to the user.

The implementation I have created here just makes an Atom notification that pops up and says the "reason" and "line" where the syntax error occurred.