### PR TITLE
Allow JSON or Node require config

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ export const provideLinter = () => {
       let configFile = helper.findFile(path, configFiles);
       if (configFile) {
         try {
-          let stylelintrc = JSON.parse(fs.readFileSync(configFile));
+          let stylelintrc = require(configFile);
           config = assign(config, stylelintrc);
         } catch (e) {
           atom.notifications.addWarning(`Invalid .stylelintrc`, {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,19 @@ export const activate = () => {
   require("atom-package-deps").install("linter-stylelint");
 };
 
+const getConfig = (configFile) => {
+  let fileContents = fs.readFileSync(configFile);
+  let config;
+
+  try {
+    config = JSON.parse(fileContents);
+  } catch (e) {
+    config = require(configFile);
+  }
+
+  return config;
+};
+
 export const provideLinter = () => {
 
   let preset = require(presetConfig());
@@ -54,9 +67,10 @@ export const provideLinter = () => {
       let configFile = helper.findFile(path, configFiles);
       if (configFile) {
         try {
-          let stylelintrc = require(configFile);
+          let stylelintrc = getConfig(configFile);
           config = assign(config, stylelintrc);
         } catch (e) {
+          console.log(e);
           atom.notifications.addWarning(`Invalid .stylelintrc`, {
             detail: `Failed to parse .stylelintrc JSON`,
             dismissable: true


### PR DESCRIPTION
When working with stylelint there are times where you may want to use json config OR stylelint configs exported by node.

This is a work around for preset configs that aren't included in the dropdown box.