### PR TITLE
Pass configBasedir to stylelint

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ import postcss   from 'postcss';
 import stylelint from 'stylelint';
 import helper    from 'atom-linter';
 import assign    from 'deep-assign';
+import nodePath  from 'path';
 
 export let config = {
   usePreset: {
@@ -78,7 +79,10 @@ export const provideLinter = () => {
       return new Promise((resolve, reject) => {
 
         postcss([
-          stylelint(config)
+          stylelint({
+            config,
+            configBasedir: nodePath.dirname(configFile)
+          })
         ]).process(text, {
           from: path
         }).then((data) => {


### PR DESCRIPTION
I was having problems when using configs that extend other configs with relative paths: the extended configs were not being loaded properly. 

As specified [in the docs](http://stylelint.io/?/docs/user-guide/postcss-plugin.md), if a config is going to use relative paths in `extends` or `plugins`, a `configBasedir` option must be passed. (Otherwise we wouldn't know what the relative paths are relative to.)  I figure that since this Atom plugin already knows the config basedir, why not play it safe and pass it every time?

When I made this change and passed `configBasedir`, the errors vanished and the linter worked as expected.