### PR TITLE
Use standalone stylelint, add configBasedir and severities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "atom-linter": "^3.3.0",
     "atom-package-deps": "^2.1.3",
     "deep-assign": "^2.0.0",
-    "postcss": "^5.0.10",
     "stylelint": "^2.0.0",
     "stylelint-config-cssrecipes": "^1.1.0",
     "stylelint-config-suitcss": "^0.5.1",


### PR DESCRIPTION
By using the stylelint API, I was able to
- remove the PostCSS dependency
- distinguishing warnings from errors (closing #5)

I also added `configBasedir` so that users can have relative paths for `extends` and `plugins` in the config files that the linter loads (cf. http://stylelint.io/?/docs/user-guide/postcss-plugin.md).

I have not developed an Atom plugin before so I'm not sure I did everything right --- but after these changes the linter worked as expected for me locally, so I think it's ok.

What do you think?