### PR TITLE
Add utf8 encoding to readFileSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ export const activate = () => {
 
 const getConfig = (configFile) => {
 
-  let contents = fs.readFileSync(configFile);
+  let contents = fs.readFileSync(configFile, 'utf8');
   let config;
 
   try {


### PR DESCRIPTION
Without this encoding the linter was not working.

(Did this change recently?)