### PR TITLE
Fix import of atom-linter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use babel';
 
-import fs        from 'fs';
-import path      from 'path';
+import fs from 'fs';
+import path from 'path';
 import { Range } from 'atom';
 import stylelint from 'stylelint';
-import helper    from 'atom-linter';
-import assign    from 'deep-assign';
-import strip     from 'strip-json-comments';
+import * as helper from 'atom-linter';
+import assign from 'deep-assign';
+import strip from 'strip-json-comments';
 
 export let config = {
   usePreset: {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "homepage": "https://github.com/AtomLinter/linter-stylelint#readme",
   "dependencies": {
-    "atom-linter": "^3.3.7",
-    "atom-package-deps": "^3.0.2",
+    "atom-linter": "^3.4.0",
+    "atom-package-deps": "^3.0.5",
     "deep-assign": "^2.0.0",
     "strip-json-comments": "^2.0.0",
-    "stylelint": "^2.3.2",
+    "stylelint": "^2.3.5",
     "stylelint-config-cssrecipes": "^1.1.0",
     "stylelint-config-suitcss": "^1.0.0",
     "stylelint-config-wordpress": "^0.2.0"


### PR DESCRIPTION
v3.4.0 of `atom-linter` should work with the current method of importing, but older methods seem to have issues. This way of importing works with both the old version and the ES6 re-write of this module.