### PR TITLE
Add option to disable if no config file is found in project

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,18 @@ export const config = {
     type: 'string',
     default: 'stylelint-config-suitcss',
     enum: ['stylelint-config-suitcss', 'stylelint-config-cssrecipes', 'stylelint-config-wordpress']
+  },
+  disableWhenNoConfig: {
+    title: 'Disable when no config file is found',
+    description: 'Either .stylelintrc or stylelint.config.js',
+    type: 'boolean',
+    default: false
   }
 };
 
 const usePreset = () => atom.config.get('linter-stylelint.usePreset');
 const presetConfig = () => atom.config.get('linter-stylelint.presetConfig');
+const disableWhenNoConfig = () => atom.config.get('linter-stylelint.disableWhenNoConfig');
 
 function createRange(editor, data) {
   // data.line & data.column might be undefined for non-fatal invalid rules,
@@ -107,6 +114,10 @@ export const provideLinter = () => {
         if (result) {
           options.config = assign(rules, result.config);
           options.configBasedir = path.dirname(result.filepath);
+        }
+
+        if (!result && disableWhenNoConfig()) {
+          return [];
         }
 
         return runStylelint(editor, options, filePath);

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -8,6 +8,7 @@ describe('The stylelint provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     atom.config.set('linter-stylelint.usePreset', true);
+    atom.config.set('linter-stylelint.disableWhenNoConfig', false);
 
     waitsForPromise(() => {
       return atom.packages.activatePackage('linter-stylelint').then(() => {
@@ -124,6 +125,20 @@ describe('The stylelint provider for Linter', () => {
         expect(atom.notifications.addError.mostRecentCall.args[0]).toEqual('Unable to parse stylelint configuration');
         expect(atom.notifications.addError.mostRecentCall.args[1].detail).toContain('>>>');
         expect(atom.notifications.addError.mostRecentCall.args[1].dismissable).toEqual(true);
+      });
+    });
+  });
+
+  it('disable when no config file is found', () => {
+    atom.config.set('linter-stylelint.disableWhenNoConfig', true);
+    spyOn(atom.notifications, 'addError').andCallFake(() => {});
+
+    waitsForPromise(() => {
+      return atom.workspace.open(path.join(__dirname, 'fixtures', 'bad', 'bad.css')).then(editor => {
+        return lint(editor);
+      }).then(messages => {
+        expect(messages.length).toEqual(0);
+        expect(atom.notifications.addError.calls.length).toEqual(0);
       });
     });
   });


### PR DESCRIPTION
First off, thanks for this plugin - def the most efficient way to stylelint :+1: 

I've added a settings option to disable linter-stylelint when no config file is found.

This prevents 'Unable to run stylelint. No rules found within configuration' errors popping up all the time when working on projects that are not using stylelint (which was making me constantly disable and enable the plugin).

I have been using this version myself with no issues and thought others might find it useful too. The tests pass (eslint and apm). Please let me know if you forsee any potential problem with it.