### PR TITLE
Add `postcss` keyword to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "keywords": [
     "css",
     "lint",
+    "postcss",
     "stylelint"
   ],
   "author": {


### PR DESCRIPTION
I went searching for PostCSS plugins and expected Stylelint to appear in the search results [here](https://atom.io/packages/search?q=postcss) or keyword results [here](https://atom.io/packages/search?utf8=%E2%9C%93&q=keyword:postcss)