### PR TITLE
Add source.scss to grammarScopes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ function runStylelint(editor, options, filePath) {
 export function provideLinter() {
   return {
     name: 'stylelint',
-    grammarScopes: ['source.css', 'source.css.scss'],
+    grammarScopes: ['source.css', 'source.scss', 'source.css.scss'],
     scope: 'file',
     lintOnFly: true,
     lint: (editor) => {
@@ -117,7 +117,10 @@ export function provideLinter() {
         configBasedir: path.dirname(filePath)
       };
 
-      if (scopes.indexOf('source.css.scss') !== -1) {
+      if (
+        scopes.indexOf('source.css.scss') !== -1 ||
+        scopes.indexOf('source.scss') !== -1
+      ) {
         options.syntax = 'scss';
       }
 


### PR DESCRIPTION
I'm using a different syntax highlighting for SCSS because the default package doesn't support nested properties. The package sets the grammar to `source.scss`, which breaks this linter. I added it, so it'll work for me (and other people, maybe?)

Thank you for your consideration.