### PR TITLE
Add note about SCSS files to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,8 @@ A plugin for [Atom Linter](https://github.com/AtomLinter/atom-linter) providing 
 $ apm install linter-stylelint
 ```
 
+linter-stylelint checks both `.css` and `.scss` files. (For `.scss` files, it automatically tells stylelint to use the right parser.)
+
 ## Config
 
 You can pass configuration to stylelint in the following ways:


### PR DESCRIPTION
I didn't know whether linter-stylelint handled SCSS files; but looking into the codebase (and trying some experiments) I see that it does. Which is great -- worth telling people about, I think!