### PR TITLE
Cap stylelint version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text eol=lf
+
+*.png binary

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "atom-package-deps": "^3.0.7",
     "cosmiconfig": "^1.1.0",
     "deep-assign": "^2.0.0",
-    "stylelint": "^4.2.0",
+    "stylelint": "4.2.0",
     "stylelint-config-cssrecipes": "^2.0.1",
     "stylelint-config-standard": "^3.0.0",
     "stylelint-config-suitcss": "^4.0.0",


### PR DESCRIPTION
Versions of `stylelint` past 4.2.0 are currently broken inside Atom. Force the version to 4.2.0 for now till this can be fixed.