### PR TITLE
Revert "Update stylelint-config-wordpress to version 3.0.0 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stylelint-config-cssrecipes": "^2.0.1",
     "stylelint-config-standard": "^3.0.0",
     "stylelint-config-suitcss": "^4.0.0",
-    "stylelint-config-wordpress": "^3.0.0"
+    "stylelint-config-wordpress": "^2.0.2"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",


### PR DESCRIPTION
Reverts AtomLinter/linter-stylelint#115

Manually checked this out, same issue as with `stylelint-config-standard`: This requires `stylelint@^4.5.0`, but doesn't list it.