### PR TITLE
Update stylelint-config-wordpress to version 3.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "stylelint-config-cssrecipes": "^2.0.1",
     "stylelint-config-standard": "^3.0.0",
     "stylelint-config-suitcss": "^4.0.0",
-    "stylelint-config-wordpress": "^2.0.2"
+    "stylelint-config-wordpress": "^3.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^5.0.0",


### PR DESCRIPTION
Clone of #115, which was merged and then reverted.

Blocked on #111.