### PR TITLE
Track and dispose of subscriptions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import * as stylelint from 'stylelint';
 import { rangeFromLineNumber } from 'atom-linter';
 import assign from 'deep-assign';
 import cosmiconfig from 'cosmiconfig';
+import { CompositeDisposable } from 'atom';
 
 export const config = {
   useStandard: {
@@ -24,6 +25,7 @@ export const config = {
 let useStandard;
 let presetConfig;
 let disableWhenNoConfig;
+let subscriptions;
 
 function createRange(editor, data) {
   // data.line & data.column might be undefined for non-fatal invalid rules,
@@ -36,12 +38,18 @@ function createRange(editor, data) {
 export function activate() {
   require('atom-package-deps').install('linter-stylelint');
 
-  atom.config.observe('linter-stylelint.useStandard', value => {
+  subscriptions = new CompositeDisposable();
+
+  subscriptions.add(atom.config.observe('linter-stylelint.useStandard', value => {
     useStandard = value;
-  });
-  atom.config.observe('linter-stylelint.disableWhenNoConfig', value => {
+  }));
+  subscriptions.add(atom.config.observe('linter-stylelint.disableWhenNoConfig', value => {
     disableWhenNoConfig = value;
-  });
+  }));
+}
+
+export function deactivate() {
+  subscriptions.dispose();
 }
 
 function runStylelint(editor, options, filePath) {


### PR DESCRIPTION
Previously the observation of the settings was leaking an observer on deactivation of the package.

Fixes #129.