### PR TITLE
Update and pin stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "atom-package-deps": "^4.0.1",
     "cosmiconfig": "^1.1.0",
     "deep-assign": "^2.0.0",
-    "stylelint": "^5.0.1",
+    "stylelint": "5.1.0",
     "stylelint-config-standard": "^4.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/AtomLinter/linter-stylelint#readme",
   "dependencies": {
-    "atom-linter": "^4.4.0",
+    "atom-linter": "^4.6.1",
     "atom-package-deps": "^4.0.1",
     "cosmiconfig": "^1.1.0",
     "deep-assign": "^2.0.0",
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.1"
+    "eslint-config-airbnb": "^6.1.0"
   },
   "eslintConfig": {
     "rules": {


### PR DESCRIPTION
As we currently only support the bundled version of `stylelint`, this should be kept as up to date as possible. Pinning this will cause GreenKeeper to send us a PR with every new version.

Also updates the minimum version of all dependencies.

Fixes #134.