### PR TITLE
Lazy require packages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,16 @@
 'use babel';
 
-import * as path from 'path';
-import * as stylelint from 'stylelint';
-import { rangeFromLineNumber } from 'atom-linter';
-import assign from 'deep-assign';
-import cosmiconfig from 'cosmiconfig';
+const lazyReq = require('lazy-req')(require);
+const { dirname } = lazyReq('path')('dirname');
+const stylelint = lazyReq('stylelint');
+const { rangeFromLineNumber } = lazyReq('atom-linter')('rangeFromLineNumber');
+const assign = lazyReq('deep-assign');
+const cosmiconfig = lazyReq('cosmiconfig');
+/**
+ * Note that this can't be loaded lazily as `atom` doesn't export it correctly
+ * for that, however as this comes from app.asar it is pre-compiled and is
+ * essentially "free" as there is no expensive compilation step.
+ */
 import { CompositeDisposable } from 'atom';
 
 export const config = {
@@ -53,7 +59,7 @@ export function deactivate() {
 }
 
 function runStylelint(editor, options, filePath) {
-  return stylelint.lint(options).then(data => {
+  return stylelint().lint(options).then(data => {
     const result = data.results.shift();
     const toReturn = [];
 
@@ -123,7 +129,7 @@ export function provideLinter() {
         code: text,
         codeFilename: filePath,
         config: rules,
-        configBasedir: path.dirname(filePath)
+        configBasedir: dirname(filePath)
       };
 
       if (
@@ -133,15 +139,15 @@ export function provideLinter() {
         options.syntax = 'scss';
       }
 
-      return cosmiconfig('stylelint', {
-        cwd: path.dirname(filePath),
+      return cosmiconfig()('stylelint', {
+        cwd: dirname(filePath),
 
         // Allow extensions on rc filenames
         rcExtensions: true
       }).then(result => {
         if (result) {
-          options.config = assign(rules, result.config);
-          options.configBasedir = path.dirname(result.filepath);
+          options.config = assign()(rules, result.config);
+          options.configBasedir = dirname(result.filepath);
         }
 
         if (!result && disableWhenNoConfig) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "cosmiconfig": "^1.1.0",
     "deep-assign": "^2.0.0",
     "stylelint": "5.4.0",
-    "stylelint-config-standard": "^5.0.0"
+    "stylelint-config-standard": "^5.0.0",
+    "lazy-req": "^1.1.0"
   },
   "devDependencies": {
     "eslint": "^2.7.0",


### PR DESCRIPTION
Utilize the `lazy-req` module to lazily require the imports.

On my system for a window reload this changes activation time from ~1000 ms to ~35 ms.

Things are even more drastic of an improvement when you look at a fresh load of atom, where package activation time goes from ~4000 ms to still just ~30 ms.

Note that this will make the very first lint take much longer, as the activation time has simply been deferred till first use.