### PR TITLE
Keep the preset pristine

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const lazyReq = require('lazy-req')(require);
 const { dirname } = lazyReq('path')('dirname');
 const stylelint = lazyReq('stylelint');
 const { rangeFromLineNumber } = lazyReq('atom-linter')('rangeFromLineNumber');
-const assign = lazyReq('deep-assign');
+const assignDeep = lazyReq('assign-deep');
 const cosmiconfig = lazyReq('cosmiconfig');
 /**
  * Note that this can't be loaded lazily as `atom` doesn't export it correctly
@@ -123,7 +123,7 @@ export function provideLinter() {
         presetConfig = require('stylelint-config-standard');
       }
       // setup base config which is based on selected preset if useStandard() is true
-      const rules = useStandard ? presetConfig : {};
+      const rules = useStandard ? assignDeep()({}, presetConfig) : {};
 
       const options = {
         code: text,
@@ -146,7 +146,7 @@ export function provideLinter() {
         rcExtensions: true
       }).then(result => {
         if (result) {
-          options.config = assign()(rules, result.config);
+          options.config = assignDeep()(rules, result.config);
           options.configBasedir = dirname(result.filepath);
         }
 

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   },
   "homepage": "https://github.com/AtomLinter/linter-stylelint#readme",
   "dependencies": {
+    "assign-deep": "^0.4.5",
     "atom-linter": "^4.6.1",
     "atom-package-deps": "^4.0.1",
     "cosmiconfig": "^1.1.0",
-    "deep-assign": "^2.0.0",
+    "lazy-req": "^1.1.0",
     "stylelint": "5.4.0",
-    "stylelint-config-standard": "^5.0.0",
-    "lazy-req": "^1.1.0"
+    "stylelint-config-standard": "^5.0.0"
   },
   "devDependencies": {
     "eslint": "^2.7.0",

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -28,20 +28,6 @@ describe('The stylelint provider for Linter', () => {
     );
   });
 
-  it('detects invalid coding style in bad.css and reports an error', () => {
-    waitsForPromise(() =>
-      atom.workspace.open(configStandardPath).then(editor => lint(editor)).then(messages => {
-        expect(messages.length).toBeGreaterThan(0);
-
-        // test only the first error
-        expect(messages[0].type).toBe('Error');
-        expect(messages[0].text).toBe('Unexpected empty block (block-no-empty)');
-        expect(messages[0].filePath).toBe(configStandardPath);
-        expect(messages[0].range).toEqual([[0, 5], [0, 7]]);
-      })
-    );
-  });
-
   it('bundles and works with stylelint-config-standard', () => {
     waitsForPromise(() =>
       atom.workspace.open(configStandardPath).then(editor => lint(editor)).then(messages => {
@@ -163,6 +149,25 @@ describe('The stylelint provider for Linter', () => {
       atom.workspace.open(ignorePath).then(editor => lint(editor)).then(messages => {
         expect(messages.length).toBe(0);
         expect(atom.notifications.addError.calls.length).toBe(0);
+      })
+    );
+  });
+
+  it("doesn't persist settings across runs", () => {
+    waitsForPromise(() =>
+      // The config for this folder breaks the block-no-empty rule
+      atom.workspace.open(invalidRulePath).then(editor => lint(editor))
+    );
+    waitsForPromise(() =>
+      // While this file uses that rule
+      atom.workspace.open(configStandardPath).then(editor => lint(editor)).then(messages => {
+        expect(messages.length).toBeGreaterThan(0);
+
+        // test only the first error
+        expect(messages[0].type).toBe('Error');
+        expect(messages[0].text).toBe('Unexpected empty block (block-no-empty)');
+        expect(messages[0].filePath).toBe(configStandardPath);
+        expect(messages[0].range).toEqual([[0, 5], [0, 7]]);
       })
     );
   });


### PR DESCRIPTION
The preset config wasn't being copied, only referenced, this means that any style configurations were changing the permanent preset instead of just that lint run. Switched from deep-assign to assign-deep as the old module had a bug where nested objects were referenced instead of copied.