### PR TITLE
Switch to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,20 +40,17 @@
     "stylelint-config-standard": "^6.0.0"
   },
   "devDependencies": {
-    "eslint": "^2.7.0",
-    "eslint-config-airbnb": "^7.0.0",
-    "eslint-plugin-react": "^4.3.0",
-    "eslint-plugin-jsx-a11y": "^0.6.2"
+    "eslint": "^2.8.0",
+    "eslint-config-airbnb-base": "^1.0.0",
+    "eslint-plugin-import": "^1.5.0"
   },
   "eslintConfig": {
     "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-console": 0
+      "comma-dangle": [2, "never"],
+      "global-require": 0,
+      "import/no-unresolved": [2, { "ignore": ["atom"] }]
     },
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/.eslintrc.js
+++ b/spec/.eslintrc.js
@@ -1,8 +1,6 @@
 module.exports = {
-  globals: {
-    waitsForPromise: true
-  },
   env: {
-    jasmine: true
+    jasmine: true,
+    atomtest: true
   }
 };


### PR DESCRIPTION
Move away from eslint-config-airbnb as it requires several extra plugins related to React that are not necessary for this package.

Closes #153.
Closes #163.