### PR TITLE
Show deprecation messages to the user

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -122,7 +122,14 @@ function runStylelint(editor, options, filePath) {
       };
     });
 
-    return toReturn.concat(invalidOptions).concat(warnings);
+    const deprecations = result.deprecations.map(deprecation => ({
+      type: 'Warning',
+      severity: 'warning',
+      html: `${escapeHTML()(deprecation.text)} (<a href="${deprecation.reference}">reference</a>)`,
+      filePath
+    }));
+
+    return toReturn.concat(invalidOptions).concat(warnings).concat(deprecations);
   }, error => {
     // was it a code parsing error?
     if (error.line) {

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -28,8 +28,6 @@ describe('The stylelint provider for Linter', () => {
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     atom.config.set('linter-stylelint.useStandard', true);
-    atom.config.set('linter-stylelint.disableWhenNoConfig', false);
-    atom.config.set('linter-stylelint.enableHtmlLinting', false);
 
     waitsForPromise(() =>
       Promise.all([
@@ -113,7 +111,7 @@ describe('The stylelint provider for Linter', () => {
     );
   });
 
-  it('show error notification on fatal stylelint runtime error', () => {
+  it('shows an error notification for a fatal stylelint runtime error', () => {
     atom.config.set('linter-stylelint.useStandard', false);
     spyOn(atom.notifications, 'addError').andCallFake(() => ({}));
     const addError = atom.notifications.addError;
@@ -131,7 +129,7 @@ describe('The stylelint provider for Linter', () => {
     );
   });
 
-  it('show error notification on an broken syntax configuration', () => {
+  it('shows an error notification with a broken syntax configuration', () => {
     atom.config.set('linter-stylelint.useStandard', false);
     spyOn(atom.notifications, 'addError').andCallFake(() => ({}));
     const addError = atom.notifications.addError;
@@ -149,7 +147,7 @@ describe('The stylelint provider for Linter', () => {
     );
   });
 
-  it('disable when no config file is found', () => {
+  it('disables when no configuration file is found', () => {
     atom.config.set('linter-stylelint.disableWhenNoConfig', true);
     spyOn(atom.notifications, 'addError').andCallFake(() => ({}));
 
@@ -161,7 +159,7 @@ describe('The stylelint provider for Linter', () => {
     );
   });
 
-  it('ignore files when files are specified in ignoreFiles', () => {
+  it('ignores files when files are specified in ignoreFiles', () => {
     spyOn(atom.notifications, 'addError').andCallFake(() => ({}));
 
     waitsForPromise(() =>
@@ -253,7 +251,6 @@ describe('The stylelint provider for Linter', () => {
       );
     });
   });
-
 
   describe('works with PostCSS files and', () => {
     it('works with stylelint-config-standard', () => {


### PR DESCRIPTION
The deprecation messages from `stylelint` were being silently ignored before this, show them to the user so they know their config needs updating.