### PR TITLE
SugarSS Support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ const baseScopes = [
   'source.css.scss',
   'source.less',
   'source.css.less',
-  'source.css.postcss'
+  'source.css.postcss',
+  'source.css.postcss.sugarss'
 ];
 const embeddedScopes = [
   'source.css.embedded.html',
@@ -34,7 +35,8 @@ const embeddedScopes = [
   'source.css.postcss.embedded.html',
   'source.postcss.embedded.html',
   'source.css.less.embedded.html',
-  'source.less.embedded.html'
+  'source.less.embedded.html',
+  'source.css.postcss.sugarss.embedded.html'
 ];
 
 function createRange(editor, data) {
@@ -206,6 +208,16 @@ export function provideLinter() {
         scopes.indexOf('source.less.embedded.html') !== -1
       ) {
         options.syntax = 'less';
+      }
+      if (
+        scopes.indexOf('source.css.postcss.sugarss') !== -1 ||
+        scopes.indexOf('source.css.postcss.sugarss.embedded.html') !== -1
+      ) {
+        options.syntax = 'sugarss';
+        // `stylelint-config-standard` isn't fully compatible with SugarSS
+        // See here for details:
+        // https://github.com/stylelint/stylelint-config-standard#using-the-config-with-sugarss-syntax
+        options.config.rules['declaration-block-trailing-semicolon'] = null;
       }
 
       return cosmiconfig()('stylelint', {

--- a/spec/fixtures/sugarss/bad.sss
+++ b/spec/fixtures/sugarss/bad.sss
@@ -1,0 +1,2 @@
+.selector
+  box-shadow: 1px 0 9px rgba(0, 0, 0, .4)

--- a/spec/fixtures/sugarss/good.sss
+++ b/spec/fixtures/sugarss/good.sss
@@ -1,0 +1,13 @@
+a
+  color: blue
+
+.multiline,
+.selector
+  box-shadow:
+    1px 0 9px rgba(0, 0, 0, 0.4),
+    1px 0 3px rgba(0, 0, 0, 0.6)
+
+// Mobile
+@media (max-width: 400px)
+  .body
+    padding: 0 10px

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -199,6 +199,8 @@ describe('The stylelint provider for Linter', () => {
   });
 
   describe('works with Less files and', () => {
+    beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-less')));
+
     it('works with stylelint-config-standard', () => {
       waitsForPromise(() =>
         atom.workspace.open(configStandardLessPath).then(editor => lint(editor)).then(messages => {
@@ -225,6 +227,8 @@ describe('The stylelint provider for Linter', () => {
   });
 
   describe('works with HTML files and', () => {
+    beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-html')));
+
     it('works with stylelint-config-standard', () => {
       atom.config.set('linter-stylelint.enableHtmlLinting', true);
       waitsForPromise(() =>
@@ -253,6 +257,8 @@ describe('The stylelint provider for Linter', () => {
   });
 
   describe('works with PostCSS files and', () => {
+    beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-postcss')));
+
     it('works with stylelint-config-standard', () => {
       waitsForPromise(() =>
         atom.workspace.open(issuesPostCSS).then(editor => lint(editor)).then(messages => {

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -19,6 +19,8 @@ const goodHtml = path.join(htmlDir, 'good.html');
 const configStandardHtmlPath = path.join(htmlDir, 'stylelint-config-standard.html');
 const goodPostCSS = path.join(__dirname, 'fixtures', 'postcss', 'styles.pcss');
 const issuesPostCSS = path.join(__dirname, 'fixtures', 'postcss', 'issues.pcss');
+const goodSugarSS = path.join(__dirname, 'fixtures', 'sugarss', 'good.sss');
+const badSugarSS = path.join(__dirname, 'fixtures', 'sugarss', 'bad.sss');
 
 const blockNoEmpty = 'Unexpected empty block (<a href="http://stylelint.io/user-guide/rules/block-no-empty">block-no-empty</a>)';
 
@@ -278,6 +280,32 @@ describe('The stylelint provider for Linter', () => {
     it('finds nothing wrong with a valid file', () => {
       waitsForPromise(() =>
         atom.workspace.open(goodPostCSS).then(editor => lint(editor)).then(messages => {
+          expect(messages.length).toBe(0);
+        })
+      );
+    });
+  });
+
+  describe('works with SugarSS files and', () => {
+    beforeEach(() => waitsForPromise(() => atom.packages.activatePackage('language-postcss')));
+
+    it('works with stylelint-config-standard', () => {
+      const nlzMessage = 'Expected a leading zero (<a href="http://stylelint.io/user-guide/rules/number-leading-zero">number-leading-zero</a>)';
+      waitsForPromise(() =>
+        atom.workspace.open(badSugarSS).then(editor => lint(editor)).then(messages => {
+          expect(messages[0].type).toBe('Error');
+          expect(messages[0].severity).toBe('error');
+          expect(messages[0].text).not.toBeDefined();
+          expect(messages[0].html).toBe(nlzMessage);
+          expect(messages[0].filePath).toBe(badSugarSS);
+          expect(messages[0].range).toEqual([[1, 37], [1, 40]]);
+        })
+      );
+    });
+
+    it('finds nothing wrong with a valid file', () => {
+      waitsForPromise(() =>
+        atom.workspace.open(goodSugarSS).then(editor => lint(editor)).then(messages => {
           expect(messages.length).toBe(0);
         })
       );


### PR DESCRIPTION
Now that `language-postcss` shows SugarSS files with a different scope, it's possible to add proper support here for this syntax.

Fixes #204.