### PR TITLE
Fix rule name linking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -194,24 +194,24 @@ export function provideLinter() {
       };
 
       if (
-        scopes.indexOf('source.css.scss') !== -1 ||
-        scopes.indexOf('source.scss') !== -1 ||
-        scopes.indexOf('source.css.scss.embedded.html') !== -1 ||
-        scopes.indexOf('source.scss.embedded.html') !== -1
+        scopes.includes('source.css.scss') ||
+        scopes.includes('source.scss') ||
+        scopes.includes('source.css.scss.embedded.html') ||
+        scopes.includes('source.scss.embedded.html')
       ) {
         options.syntax = 'scss';
       }
       if (
-        scopes.indexOf('source.css.less') !== -1 ||
-        scopes.indexOf('source.less') !== -1 ||
-        scopes.indexOf('source.css.less.embedded.html') !== -1 ||
-        scopes.indexOf('source.less.embedded.html') !== -1
+        scopes.includes('source.css.less') ||
+        scopes.includes('source.less') ||
+        scopes.includes('source.css.less.embedded.html') ||
+        scopes.includes('source.less.embedded.html')
       ) {
         options.syntax = 'less';
       }
       if (
-        scopes.indexOf('source.css.postcss.sugarss') !== -1 ||
-        scopes.indexOf('source.css.postcss.sugarss.embedded.html') !== -1
+        scopes.includes('source.css.postcss.sugarss') ||
+        scopes.includes('source.css.postcss.sugarss.embedded.html')
       ) {
         options.syntax = 'sugarss';
         // `stylelint-config-standard` isn't fully compatible with SugarSS

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,9 @@ function generateHTMLMessage(message) {
   }
 
   // Escape any HTML in the message, and replace the rule ID with a link
-  return escapeHTML()(message.text).replace(message.rule, `<a href="${url}">${message.rule}</a>`);
+  return escapeHTML()(message.text).replace(
+    `(${message.rule})`, `(<a href="${url}">${message.rule}</a>)`
+  );
 }
 
 function runStylelint(editor, options, filePath) {


### PR DESCRIPTION
Before rules like "indentation" were being highlighted in the middle of the message.