### PR TITLE
Only attempt extraction in embedded code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -165,11 +165,11 @@ export function provideLinter() {
     lintOnFly: true,
     lint: editor => {
       const scopes = editor.getLastCursor().getScopeDescriptor().getScopesArray();
+      // Check whether the current scope is an embedded one
+      const currentlyEmbedded = scopes.filter(scope => embeddedScopes.includes(scope)).length > 0;
 
       // If in an embedded block and linting embedded scopes is disabled return
-      if (!enableHtmlLinting &&
-        scopes.filter((scope) => embeddedScopes.includes(scope)).length > 0
-      ) {
+      if (currentlyEmbedded && !enableHtmlLinting) {
         return Promise.resolve([]);
       }
 
@@ -191,9 +191,13 @@ export function provideLinter() {
         code: text,
         codeFilename: filePath,
         config: rules,
-        configBasedir: dirname(filePath),
-        extractStyleTagsFromHtml: enableHtmlLinting
+        configBasedir: dirname(filePath)
       };
+
+      // Only enable extraction if we are in an embedded scope
+      if (currentlyEmbedded) {
+        options.extractStyleTagsFromHtml = enableHtmlLinting;
+      }
 
       if (
         scopes.includes('source.css.scss') ||


### PR DESCRIPTION
Only specify the `extractStyleTagsFromHtml` option to stylelint if we are in an embedded block of code.

Closes #224.