### PR TITLE
Update CI Configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,4 @@
-notifications:
-  email:
-    on_success: never
-    on_failure: change
-
-branches:
-  only:
-    - master
-
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
-
-git:
-  depth: 10
-
-sudo: false
-
-os:
-  - linux
-  - osx
-
+# Project specific config
 env:
   global:
     # Pre-install the required language file as package activation doesn't wait
@@ -27,6 +8,31 @@ env:
   matrix:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
+
+os:
+  - linux
+  - osx
+
+# Installed for linting the project
+language: node_js
+node_js: "6"
+
+# Generic setup follows
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
 
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 
 install:
   # Install Node.js to run any configured linters
-  - ps: Install-Product node 5
+  - ps: Install-Product node 6
 
 build_script:
   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))

--- a/circle.yml
+++ b/circle.yml
@@ -1,20 +1,21 @@
 dependencies:
-  pre:
-    # Force updating wget due to the current containers being too out of date
-    - sudo apt-get update
-    - sudo apt-get install wget
   override:
-    - wget -O atom-amd64.deb https://atom.io/download/deb
-    # - sudo apt-get update # Cut out until wget is fixed on the containers
+    - curl -L https://atom.io/download/deb -o atom-amd64.deb
     - sudo dpkg --install atom-amd64.deb || true
+    - sudo apt-get update
     - sudo apt-get -f install
     - apm install
     # Pre-install the required language file as package activation doesn't wait
     # for the installation to complete.
     - apm install language-postcss
+
 test:
   override:
     - atom -v
     - apm -v
-    - npm test
+    - npm run lint
     - apm test
+
+machine:
+  node:
+    version: 6


### PR DESCRIPTION
Ensure that Node.js v6 is available for _future_ usage of `eslint@3`.