### PR TITLE
Add default config with rules object for SugarSS

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,11 @@ export function provideLinter() {
         presetConfig = require('stylelint-config-standard');
       }
       // Setup base config if useStandard() is true
-      const rules = useStandard ? assignDeep()({}, presetConfig) : {};
+      const defaultConfig = {
+        rules: {}
+      };
+
+      const rules = useStandard ? assignDeep()({}, presetConfig) : defaultConfig;
 
       const options = {
         code: text,


### PR DESCRIPTION
it must fix issue with SugarSS.

When we set `declaration-block-trailing-semicolon` to `null` rules may not exist. 