### PR TITLE
Update the CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,31 @@
-# Project specific config
+### Project specific config ###
+
+# Installed for linting the project
+language: node_js
+
+matrix:
+  include:
+    - os: linux
+      node_js: "6"
+      env: ATOM_CHANNEL=stable
+
+    - os: linux
+      node_js: "6"
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      node_js: "6"
+      env: ATOM_CHANNEL=stable
+
 env:
   global:
     # Pre-install the required language file as package activation doesn't wait
     # for the installation to complete.
     - APM_TEST_PACKAGES="language-postcss"
+    - ATOM_LINT_WITH_BUNDLED_NODE="false"
 
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
-
-os:
-  - linux
-  - osx
-
-# Installed for linting the project
-language: node_js
-node_js: "6"
-
-# Generic setup follows
-script: 'curl -Ls https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.sh | sh'
+### Generic setup follows ###
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,27 @@
-version: "{build}"
-platform: x64
-branches:
-  only:
-    - master
-clone_depth: 10
-skip_tags: true
-test: off
-deploy: off
+### Project specific config ###
 environment:
   APM_TEST_PACKAGES: language-postcss
+  ATOM_LINT_WITH_BUNDLED_NODE: "false"
+
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
 
 install:
   # Install Node.js to run any configured linters
   - ps: Install-Product node 6
 
+### Generic setup follows ###
 build_script:
-  - ps: iex ((new-object net.webclient).DownloadString('https://github.com/Arcanemagus/ci/raw/atomlinter/build-package.ps1'))
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
+branches:
+  only:
+    - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
+test: off
+deploy: off

--- a/circle.yml
+++ b/circle.yml
@@ -1,23 +1,16 @@
-dependencies:
-  override:
-    - curl -L https://atom.io/download/deb -o atom-amd64.deb
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get update
-    - sudo apt-get -f install
-    # Pre-install the required language file as package activation doesn't wait
-    # for the installation to complete.
-    - apm install language-postcss
-
 test:
   override:
-    - npm install
-    - npm run lint
-    - rm -Rf node_modules
-    - atom -v
-    - apm -v
-    - apm install --production
-    - apm test
+    - curl -s https://raw.githubusercontent.com/Arcanemagus/ci/atomlinter/build-package.sh | sh
+
+dependencies:
+  override:
+    - echo "Managed in the script"
 
 machine:
   node:
     version: 6
+  environment:
+    ATOM_LINT_WITH_BUNDLED_NODE: "false"
+    # Pre-install the required language file as package activation doesn't wait
+    # for the installation to complete.
+    APM_TEST_PACKAGES: "language-postcss"


### PR DESCRIPTION
* Send the flag to lint with the system Node.js, fixing stable channel builds
* Move AppVeyor and Travis-CI back to the official repo script
* Cut out the beta channel build on macOS
* Fix the styling on the AppVeyor script
* Move CircleCI to the same script Travis-CI and AppVeyor are running on, but the customized version.