### PR TITLE
Add timing instrumentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,22 @@ const baseScopes = [
   'source.css.postcss.sugarss'
 ];
 
+function startMeasure(baseName) {
+  performance.mark(`${baseName}-start`);
+}
+
+function endMeasure(baseName) {
+  if (atom.inDevMode()) {
+    performance.mark(`${baseName}-end`);
+    performance.measure(baseName, `${baseName}-start`, `${baseName}-end`);
+    // eslint-disable-next-line no-console
+    console.log(`${baseName} took: `, performance.getEntriesByName(baseName)[0].duration);
+    performance.clearMarks(`${baseName}-end`);
+    performance.clearMeasures(baseName);
+  }
+  performance.clearMarks(`${baseName}-start`);
+}
+
 function createRange(editor, data) {
   if (!Object.hasOwnProperty.call(data, 'line') && !Object.hasOwnProperty.call(data, 'column')) {
     // data.line & data.column might be undefined for non-fatal invalid rules,
@@ -46,6 +62,7 @@ function createRange(editor, data) {
 }
 
 export function activate() {
+  startMeasure('linter-stylelint: Activation');
   require('atom-package-deps').install('linter-stylelint');
 
   subscriptions = new CompositeDisposable();
@@ -59,6 +76,8 @@ export function activate() {
   subscriptions.add(atom.config.observe('linter-stylelint.showIgnored', value => {
     showIgnored = value;
   }));
+
+  endMeasure('linter-stylelint: Activation');
 }
 
 export function deactivate() {
@@ -97,12 +116,15 @@ function generateHTMLMessage(message) {
 }
 
 function runStylelint(editor, options, filePath) {
+  startMeasure('linter-stylelint: Stylelint');
   return stylelint().lint(options).then(data => {
+    endMeasure('linter-stylelint: Stylelint');
+    startMeasure('linter-stylelint: Parsing results');
     const result = data.results.shift();
-    const toReturn = [];
 
     if (!result) {
-      return toReturn;
+      endMeasure('linter-stylelint: Parsing results');
+      return [];
     }
 
     const invalidOptions = result.invalidOptionWarnings.map(msg => ({
@@ -141,14 +163,20 @@ function runStylelint(editor, options, filePath) {
       });
     }
 
-    return toReturn
+    const toReturn = []
       .concat(invalidOptions)
       .concat(warnings)
       .concat(deprecations)
       .concat(ignored);
+
+    endMeasure('linter-stylelint: Parsing results');
+    endMeasure('linter-stylelint: Lint');
+    return toReturn;
   }, error => {
+    endMeasure('linter-stylelint: Stylelint');
     // Was it a code parsing error?
     if (error.line) {
+      endMeasure('linter-stylelint: Lint');
       return [{
         type: 'Error',
         severity: 'error',
@@ -165,6 +193,7 @@ function runStylelint(editor, options, filePath) {
       dismissable: true
     });
 
+    endMeasure('linter-stylelint: Lint');
     return [];
   });
 }
@@ -176,12 +205,14 @@ export function provideLinter() {
     scope: 'file',
     lintOnFly: true,
     lint: editor => {
+      startMeasure('linter-stylelint: Lint');
       const scopes = editor.getLastCursor().getScopeDescriptor().getScopesArray();
 
       const filePath = editor.getPath();
       const text = editor.getText();
 
       if (!text) {
+        endMeasure('linter-stylelint: Lint');
         return Promise.resolve([]);
       }
 
@@ -217,6 +248,7 @@ export function provideLinter() {
         options.config.rules['declaration-block-trailing-semicolon'] = null;
       }
 
+      startMeasure('linter-stylelint: Cosmiconfig');
       return cosmiconfig()('stylelint', {
         cwd: dirname(filePath),
         rcExtensions: true // Allow extensions on rc filenames
@@ -227,9 +259,12 @@ export function provideLinter() {
         }
 
         if (!result && disableWhenNoConfig) {
+          endMeasure('linter-stylelint: Cosmiconfig');
+          endMeasure('linter-stylelint: Lint');
           return [];
         }
 
+        endMeasure('linter-stylelint: Cosmiconfig');
         return runStylelint(editor, options, filePath);
       }, error => {
         // If we got here, cosmiconfig failed to parse the configuration
@@ -239,6 +274,8 @@ export function provideLinter() {
           detail: error.message,
           dismissable: true
         });
+        endMeasure('linter-stylelint: Cosmiconfig');
+        endMeasure('linter-stylelint: Lint');
       }).then(result => result || []);
     }
   };

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     },
     "env": {
       "es6": true,
-      "node": true
+      "node": true,
+      "browser": true
     }
   },
   "package-deps": [


### PR DESCRIPTION
When Atom is launched in developer mode, show how long different aspects of the linting take. Currently recorded:

* Package activation
* Running cosmicconfig
* Running stylelint
* Parsing the stylelint results
* The overal time to run this package's lint() method

![image](https://cloud.githubusercontent.com/assets/427137/18100973/d3c0e9f2-6ea1-11e6-9357-ecf8412261d4.png)
