### PR TITLE
Add table@3.7.9 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "escape-html": "^1.0.3",
     "lazy-req": "^1.1.0",
     "stylelint": "7.2.0",
-    "stylelint-config-standard": "^13.0.0"
+    "stylelint-config-standard": "^13.0.0",
+    "table": "3.7.9"
   },
   "devDependencies": {
     "eslint": "^3.5.0",


### PR DESCRIPTION
This is an effort to force resolution of `stylelint`'s dependencies to use this version of `table`, as versions past this currently include a dependency on Ajv, which is unable to be used inside Atom (or any other environment where eval is blocked).

(temporarily) Fixes #269.