### PR TITLE
Prevent race condition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,6 +120,14 @@ function runStylelint(editor, options, filePath) {
   return stylelint().lint(options).then((data) => {
     endMeasure('linter-stylelint: Stylelint');
     startMeasure('linter-stylelint: Parsing results');
+
+    if (options.code !== editor.getText()) {
+      // The editor contents have changed since the lint was requested, tell
+      //   Linter not to update the results
+      endMeasure('linter-stylelint: Parsing results');
+      return null;
+    }
+
     const result = data.results.shift();
 
     if (!result) {


### PR DESCRIPTION
If the editor contents have changed since the lint was requested, return `null` telling Linter to simply not update the results.