### PR TITLE
End Lint measure properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -125,6 +125,7 @@ function runStylelint(editor, options, filePath) {
       // The editor contents have changed since the lint was requested, tell
       //   Linter not to update the results
       endMeasure('linter-stylelint: Parsing results');
+      endMeasure('linter-stylelint: Lint');
       return null;
     }
 
@@ -132,6 +133,7 @@ function runStylelint(editor, options, filePath) {
 
     if (!result) {
       endMeasure('linter-stylelint: Parsing results');
+      endMeasure('linter-stylelint: Lint');
       return [];
     }
 


### PR DESCRIPTION
Looks like there were two cases where the `Lint` measure wasn't being
properly closed in the case of an early return from results processing.