### PR TITLE
Fix configBaseDir

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -235,13 +235,20 @@ export function provideLinter() {
         rules: {}
       };
 
+      // Base the config in the project directory
+      let configBasedir = atom.project.relativizePath(filePath)[0];
+      if (configBasedir === null) {
+        // Falling back to the file directory if no project is found
+        configBasedir = dirname(filePath);
+      }
+
       const rules = useStandard ? assignDeep()({}, presetConfig) : defaultConfig;
 
       const options = {
         code: text,
         codeFilename: filePath,
         config: rules,
-        configBasedir: dirname(filePath)
+        configBasedir
       };
 
       if (scopes.includes('source.css.scss') || scopes.includes('source.scss')) {


### PR DESCRIPTION
Set the `configBaseDir` to the project directory, falling back to the file
directory if that isn't found. Note that the `cwd` for searching for the
file's configuration must still be the directory of the file.

Fixes #263.