### PR TITLE
Remove table dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "escape-html": "^1.0.3",
     "lazy-req": "^1.1.0",
     "stylelint": "7.4.2",
-    "stylelint-config-standard": "^13.0.0",
-    "table": "3.7.9"
+    "stylelint-config-standard": "^13.0.0"
   },
   "devDependencies": {
     "eslint": "^3.6.0",


### PR DESCRIPTION
As of v3.8.3 `table` is no longer causing `eval()` issues so we can remove the attempt to force v3.7.9.