### PR TITLE
Add support for styled components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,8 @@ const baseScopes = [
   'source.less',
   'source.css.less',
   'source.css.postcss',
-  'source.css.postcss.sugarss'
+  'source.css.postcss.sugarss',
+  'source.inside-js.css.styled'
 ];
 
 function startMeasure(baseName) {


### PR DESCRIPTION
This PR adds `source.inside-js.css.styled` to the `baseScopes` in order to support linting of @mxstbr's [styled components](https://styled-components.com/).