### PR TITLE
Grammars scopes to config + added support to styled-components

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,18 +21,10 @@ let useStandard;
 let presetConfig;
 let disableWhenNoConfig;
 let showIgnored;
+let grammarScopes;
 
 // Internal vars
 let subscriptions;
-const baseScopes = [
-  'source.css',
-  'source.scss',
-  'source.css.scss',
-  'source.less',
-  'source.css.less',
-  'source.css.postcss',
-  'source.css.postcss.sugarss'
-];
 
 function startMeasure(baseName) {
   performance.mark(`${baseName}-start`);
@@ -75,6 +67,9 @@ export function activate() {
   }));
   subscriptions.add(atom.config.observe('linter-stylelint.showIgnored', (value) => {
     showIgnored = value;
+  }));
+  subscriptions.add(atom.config.observe('linter-stylelint.grammarScopes', (value) => {
+    grammarScopes = value;
   }));
 
   endMeasure('linter-stylelint: Activation');
@@ -216,7 +211,7 @@ const runStylelint = async (editor, options, filePath) => {
 export function provideLinter() {
   return {
     name: 'stylelint',
-    grammarScopes: baseScopes,
+    grammarScopes,
     scope: 'file',
     lintOnFly: true,
     lint: async (editor) => {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,8 @@
   "devDependencies": {
     "eslint": "^3.12.0",
     "eslint-config-airbnb-base": "^11.0.0",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "stylelint-processor-styled-components": "^0.0.4"
   },
   "eslintConfig": {
     "rules": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,33 @@
       "title": "Show message when a file is ignored",
       "type": "boolean",
       "default": false
+    },
+    "grammarScopes": {
+      "title": "Enable for grammars",
+      "type": "array",
+      "default": [
+        "source.css",
+        "source.scss",
+        "source.css.scss",
+        "source.less",
+        "source.css.less",
+        "source.css.postcss",
+        "source.css.postcss.sugarss",
+        "source.inside-js.css.styled"
+      ],
+      "items": {
+        "type": "string",
+        "enum": [
+          "source.css",
+          "source.scss",
+          "source.css.scss",
+          "source.less",
+          "source.css.less",
+          "source.css.postcss",
+          "source.css.postcss.sugarss",
+          "source.inside-js.css.styled"
+        ]
+      }
     }
   },
   "homepage": "https://github.com/AtomLinter/linter-stylelint#readme",

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ apm install linter-stylelint
 ```
 
 linter-stylelint runs `stylelint` against your CSS, SCSS, Less, PostCSS,
-and SugarSS files.
+SugarSS, and [Styled Components](https://github.com/styled-components/styled-components#linting) files.
 
 ## Configuration
 

--- a/spec/fixtures/styled-components/.stylelintrc
+++ b/spec/fixtures/styled-components/.stylelintrc
@@ -1,0 +1,7 @@
+{
+  "processors": ["stylelint-processor-styled-components"],
+  "rules": {
+    "declaration-block-trailing-semicolon": "always"
+  },
+  "syntax": "scss"
+}

--- a/spec/fixtures/styled-components/bad.js
+++ b/spec/fixtures/styled-components/bad.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import styled from 'styled-components';
+
+// no semicolon after blue
+const BlueDiv = styled.div`
+  color: blue
+`;
+
+export default BlueDiv;

--- a/spec/fixtures/styled-components/good.js
+++ b/spec/fixtures/styled-components/good.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BlueDiv = styled.div`
+  color: blue;
+`;
+
+export default BlueDiv;

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -18,6 +18,8 @@ const goodPostCSS = path.join(__dirname, 'fixtures', 'postcss', 'styles.pcss');
 const issuesPostCSS = path.join(__dirname, 'fixtures', 'postcss', 'issues.pcss');
 const goodSugarSS = path.join(__dirname, 'fixtures', 'sugarss', 'good.sss');
 const badSugarSS = path.join(__dirname, 'fixtures', 'sugarss', 'bad.sss');
+const goodStyledComponents = path.join(__dirname, 'fixtures', 'styled-components', 'good.js');
+const badStyledComponents = path.join(__dirname, 'fixtures', 'styled-components', 'bad.js');
 
 const blockNoEmpty = 'Unexpected empty block (<a href="http://stylelint.io/user-guide/rules/block-no-empty">block-no-empty</a>)';
 
@@ -296,6 +298,35 @@ describe('The stylelint provider for Linter', () => {
     it('finds nothing wrong with a valid file', () => {
       waitsForPromise(() =>
         atom.workspace.open(goodSugarSS).then(editor => lint(editor)).then((messages) => {
+          expect(messages.length).toBe(0);
+        })
+      );
+    });
+  });
+
+  describe('works with JS files (language-babel) with Styled Components and', () => {
+    beforeEach(() => {
+      atom.config.set('linter-stylelint.disableWhenNoConfig', false);
+      waitsForPromise(() => atom.packages.activatePackage('language-babel'));
+    });
+
+    it('correctly detects an error present in a file', () => {
+      const ntscMessage = 'Expected a trailing semicolon (<a href="http://stylelint.io/user-guide/rules/declaration-block-trailing-semicolon">declaration-block-trailing-semicolon</a>)';
+      waitsForPromise(() =>
+        atom.workspace.open(badStyledComponents).then(editor => lint(editor)).then((messages) => {
+          expect(messages[0].type).toBe('Error');
+          expect(messages[0].severity).toBe('error');
+          expect(messages[0].text).not.toBeDefined();
+          expect(messages[0].html).toBe(ntscMessage);
+          expect(messages[0].filePath).toBe(badStyledComponents);
+          expect(messages[0].range).toEqual([[5, 12], [5, 13]]);
+        })
+      );
+    });
+
+    it('finds nothing wrong with a valid file', () => {
+      waitsForPromise(() =>
+        atom.workspace.open(goodStyledComponents).then(editor => lint(editor)).then((messages) => {
           expect(messages.length).toBe(0);
         })
       );


### PR DESCRIPTION
Hi there!

I've been using [Styled Components] for a while, and recently we decided to add **stylelint** to our validation pipeline.

In addition to lint from the console, I wanted to get some feedback directly in Atom, and was then when I found this package.

I installed the package, but to my surprise I was not getting any feedback, so after digging a while I notice that this was caused because the grammar for Styled Components was not included in the currently supported ones.

In order to add a new grammar there were 2 paths to take:
1. Add the new grammar directly to the [baseScopes array](https://github.com/AtomLinter/linter-stylelint/blob/master/lib/index.js#L27)
2. Promote supported grammars to be a config value, so this way users would be able to specify the grammars they want to lint

After analyzing the pros and cons I ended up picking the nice and marvelous path 2 :sparkles:.

Hope you like this :slightly_smiling_face: