### PR TITLE
Remove macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
   matrix:
     - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
+    # - ATOM_CHANNEL=beta
 
 ### Generic setup follows ###
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,16 @@
 ### Project specific config ###
 language: generic
-
-matrix:
-  include:
-    - os: linux
-      env: ATOM_CHANNEL=stable
-
-    - os: linux
-      env: ATOM_CHANNEL=beta
-
-    - os: osx
-      env: ATOM_CHANNEL=stable
+os: linux
 
 env:
   global:
     # Pre-install the required language file as package activation doesn't wait
     # for the installation to complete.
     - APM_TEST_PACKAGES="language-postcss"
+
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
 
 ### Generic setup follows ###
 script:

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,11 @@
-test:
+dependencies:
   override:
     - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
     - chmod u+x build-package.sh
-    - ./build-package.sh
 
-dependencies:
+test:
   override:
-    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
-    - echo "Managed in the script"
+    - ./build-package.sh
 
 machine:
   environment:


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing. As there have been virtually no bugs found specifically on this platform it isn't worth the developer headaches of waiting forever for builds on it.

Also re-orders the CircleCI config to match atom/ci.