### PR TITLE
Improve activation time

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,28 +1,23 @@
 'use babel';
 
-/**
- * Note that this can't be loaded lazily as `atom` doesn't export it correctly
- * for that, however as this comes from app.asar it is pre-compiled and is
- * essentially "free" as there is no expensive compilation step.
- */
 // eslint-disable-next-line import/extensions, import/no-extraneous-dependencies
 import { CompositeDisposable } from 'atom';
 
-const lazyReq = require('lazy-req')(require);
-
-const { dirname } = lazyReq('path')('dirname');
-const stylelint = lazyReq('stylelint');
-const { generateRange } = lazyReq('atom-linter')('generateRange');
-const assignDeep = lazyReq('assign-deep');
-const escapeHTML = lazyReq('escape-html');
+// Dependencies
+let dirname;
+let stylelint;
+let assignDeep;
+let escapeHTML;
+let presetConfig;
+let generateRange;
 
 // Settings
 let useStandard;
-let presetConfig;
 let disableWhenNoConfig;
 let showIgnored;
 
 // Internal vars
+let idleCallbacks;
 let subscriptions;
 const baseScopes = [
   'source.css',
@@ -33,6 +28,27 @@ const baseScopes = [
   'source.css.postcss',
   'source.css.postcss.sugarss'
 ];
+
+function loadDeps() {
+  if (!dirname) {
+    dirname = require('path').dirname;
+  }
+  if (!stylelint) {
+    stylelint = require('stylelint');
+  }
+  if (!generateRange) {
+    generateRange = require('atom-linter').generateRange;
+  }
+  if (!assignDeep) {
+    assignDeep = require('assign-deep');
+  }
+  if (!escapeHTML) {
+    escapeHTML = require('escape-html');
+  }
+  if (!presetConfig) {
+    presetConfig = require('stylelint-config-standard');
+  }
+}
 
 function startMeasure(baseName) {
   const markName = `${baseName}-start`;
@@ -69,7 +85,17 @@ function createRange(editor, data) {
 
 export function activate() {
   startMeasure('linter-stylelint: Activation');
-  require('atom-package-deps').install('linter-stylelint');
+  idleCallbacks = new Set();
+  let depsCallbackID;
+  const installLinterStylelintDeps = () => {
+    idleCallbacks.delete(depsCallbackID);
+    if (!atom.inSpecMode()) {
+      require('atom-package-deps').install('linter-stylelint');
+    }
+    loadDeps();
+  };
+  depsCallbackID = window.requestIdleCallback(installLinterStylelintDeps);
+  idleCallbacks.add(depsCallbackID);
 
   subscriptions = new CompositeDisposable();
 
@@ -87,12 +113,14 @@ export function activate() {
 }
 
 export function deactivate() {
+  idleCallbacks.forEach(callbackID => window.cancelIdleCallback(callbackID));
+  idleCallbacks.clear();
   subscriptions.dispose();
 }
 
 function generateHTMLMessage(message) {
   if (!message.rule || message.rule === 'CssSyntaxError') {
-    return escapeHTML()(message.text);
+    return escapeHTML(message.text);
   }
 
   const ruleParts = message.rule.split('/');
@@ -116,7 +144,7 @@ function generateHTMLMessage(message) {
   }
 
   // Escape any HTML in the message, and replace the rule ID with a link
-  return escapeHTML()(message.text).replace(
+  return escapeHTML(message.text).replace(
     `(${message.rule})`, `(<a href="${url}">${message.rule}</a>)`
   );
 }
@@ -159,7 +187,7 @@ const parseResults = (editor, options, results, filePath) => {
   const deprecations = results.deprecations.map(deprecation => ({
     type: 'Warning',
     severity: 'warning',
-    html: `${escapeHTML()(deprecation.text)} (<a href="${deprecation.reference}">reference</a>)`,
+    html: `${escapeHTML(deprecation.text)} (<a href="${deprecation.reference}">reference</a>)`,
     filePath
   }));
 
@@ -188,7 +216,7 @@ const runStylelint = async (editor, options, filePath) => {
   startMeasure('linter-stylelint: Stylelint');
   let data;
   try {
-    data = await stylelint().lint(options);
+    data = await stylelint.lint(options);
   } catch (error) {
     endMeasure('linter-stylelint: Stylelint');
     // Was it a code parsing error?
@@ -237,10 +265,9 @@ export function provideLinter() {
         return [];
       }
 
-      // Require stylelint-config-standard if it hasn't already been loaded
-      if (!presetConfig && useStandard) {
-        presetConfig = require('stylelint-config-standard');
-      }
+      // Force the dependencies to load if they haven't already
+      loadDeps();
+
       // Setup base config if useStandard() is true
       const defaultConfig = {
         rules: {}
@@ -253,7 +280,7 @@ export function provideLinter() {
         configBasedir = dirname(filePath);
       }
 
-      const rules = useStandard ? assignDeep()({}, presetConfig) : defaultConfig;
+      const rules = useStandard ? assignDeep({}, presetConfig) : defaultConfig;
 
       const options = {
         code: text,
@@ -284,11 +311,10 @@ export function provideLinter() {
         options.config.rules['declaration-block-semicolon-space-after'] = null;
         options.config.rules['declaration-block-semicolon-space-before'] = null;
         options.config.rules['declaration-block-trailing-semicolon'] = null;
-        options.config.rules['declaration-block-trailing-semicolon'] = null;
       }
 
       startMeasure('linter-stylelint: Create Linter');
-      const stylelintLinter = await stylelint().createLinter();
+      const stylelintLinter = await stylelint.createLinter();
       endMeasure('linter-stylelint: Create Linter');
 
       startMeasure('linter-stylelint: Config');
@@ -312,7 +338,7 @@ export function provideLinter() {
       endMeasure('linter-stylelint: Config');
 
       if (foundConfig) {
-        options.config = assignDeep()(rules, foundConfig.config);
+        options.config = assignDeep(rules, foundConfig.config);
         options.configBasedir = dirname(foundConfig.filepath);
       }
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.0.1",
     "escape-html": "^1.0.3",
-    "lazy-req": "^2.0.0",
     "stylelint": "7.10.1",
     "stylelint-config-standard": "^16.0.0"
   },


### PR DESCRIPTION
Move dependency loading from using the `lazy-require` module to code here allowing opportunistic loading. Move package dependency checking to an idle callback allowing Atom to defer that work till it isn't busy with other packages.