### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
   matrix:
     - ATOM_CHANNEL=stable
-    # - ATOM_CHANNEL=beta
+    - ATOM_CHANNEL=beta
 
 ### Generic setup follows ###
 script:
@@ -30,12 +30,16 @@ branches:
 git:
   depth: 10
 
+dist: trusty
+
 sudo: false
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - build-essential
-    - git
-    - libgnome-keyring-dev
+    - g++-6
     - fakeroot
+    - git
+    - libsecret-1-dev


### PR DESCRIPTION
* Re-enable beta builds on Travis CI.
* Move to the Trusty based image to allow Atom stable to run.
* Update the pre-installed OS packages to allow Atom beta to run.