### PR TITLE
Set proper configBaseDir for default configurations

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,10 +1,12 @@
 'use babel';
 
-import { dirname } from 'path';
 import stylelint from 'stylelint';
 import assignDeep from 'assign-deep';
 import { generateRange } from 'atom-linter';
 import presetConfig from 'stylelint-config-standard';
+
+// Internal variables
+let packagePath;
 
 export function startMeasure(baseName) {
   const markName = `${baseName}-start`;
@@ -168,7 +170,7 @@ export const runStylelint = async (editor, stylelintOptions, filePath, settings)
   return parseResults(editor, results, filePath, settings.showIgnored);
 };
 
-export function getDefaultConfig(syntax, filePath) {
+export function getDefaultConfig(syntax) {
   const defaultConfig = assignDeep({}, presetConfig);
 
   if (syntax === 'sugarss') {
@@ -188,13 +190,12 @@ export function getDefaultConfig(syntax, filePath) {
     defaultConfig.rules['declaration-block-trailing-semicolon'] = null;
   }
 
-  // Base the config in the project directory
-  let [configBasedir] = atom.project.relativizePath(filePath);
-  if (configBasedir === null) {
-    // Falling back to the file directory if no project is found
-    configBasedir = dirname(filePath);
+  // Since the user hasn't provided a configuration use the package as the base
+  // so the bundled `stylelint-config-standard` will work.
+  if (!packagePath) {
+    packagePath = atom.packages.resolvePackagePath('linter-stylelint');
   }
-  defaultConfig.configBasedir = configBasedir;
+  defaultConfig.configBasedir = packagePath;
 
   return defaultConfig;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ import { CompositeDisposable } from 'atom';
 let helpers;
 let dirname;
 let stylelint;
-let assignDeep;
 
 function loadDeps() {
   if (!helpers) {
@@ -18,9 +17,6 @@ function loadDeps() {
   }
   if (!stylelint) {
     stylelint = require('stylelint');
-  }
-  if (!assignDeep) {
-    assignDeep = require('assign-deep');
   }
 }
 
@@ -101,11 +97,9 @@ export default {
           return [];
         }
 
-        const rules = {};
         const options = {
           code: text,
-          codeFilename: filePath,
-          config: { rules }
+          codeFilename: filePath
         };
 
         const scopes = editor.getLastCursor().getScopeDescriptor().getScopesArray();
@@ -149,7 +143,7 @@ export default {
 
         if (foundConfig) {
           // We have a configuration from Stylelint
-          options.config = assignDeep(rules, foundConfig.config);
+          options.config = foundConfig.config;
           options.configBasedir = dirname(foundConfig.filepath);
         } else if (this.disableWhenNoConfig) {
           // No configuration, and linting without one is disabled
@@ -157,8 +151,8 @@ export default {
           return [];
         } else if (this.useStandard) {
           // No configuration, but using the standard is enabled
-          const defaultConfig = helpers.getDefaultConfig(options.syntax, filePath);
-          assignDeep(rules, defaultConfig.rules);
+          const defaultConfig = helpers.getDefaultConfig(options.syntax);
+          options.config = { rules: defaultConfig.rules };
           if (defaultConfig.extends) {
             options.config.extends = defaultConfig.extends;
           }


### PR DESCRIPTION
When a user has failed to provide a configuration for their project and we are generating one from the default `stylelint-config-standard`, the `configBaseDir` needs to be set to the location where those rules can be found. In this case that is the location of this package, not the location of the project being linted as the user has no configuration of their own and thus shouldn't be expected to have installed it in their project.

Fixes https://github.com/AtomLinter/linter-stylelint/issues/357.