### PR TITLE
Improve docs for disable when no config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
       "default": false
     },
     "disableWhenNoConfig": {
-      "title": "Disable when no config file is found",
-      "description": "Either .stylelintrc or stylelint.config.js",
+      "title": "Disable when no config is found",
+      "description": "You can find the list of supported formats in the [stylelint docs](https://stylelint.io/user-guide/configuration/#loading-the-configuration-object).",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
Hi, thanks for the atom package, works very well.

I'm doing this PR to improve the description of the `disableWhenNoConfig` option, because `stylelint` also supports a `stylelint` property in `package.json` and this extension will run if it exists, right?

