### PR TITLE
Bump minimum assign-deep to v0.4.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "homepage": "https://github.com/AtomLinter/linter-stylelint#readme",
   "dependencies": {
-    "assign-deep": "^0.4.5",
+    "assign-deep": "^0.4.7",
     "atom-linter": "^10.0.0",
     "atom-package-deps": "^4.6.0",
     "resolve": "^1.8.1",


### PR DESCRIPTION
Versions earlier than v0.4.7 had a [minor security issue](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3720).