### PR TITLE
Support linting in Vue single-file components

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   environment:
     # Pre-install the required language file as package activation doesn't wait
     # for the installation to complete.
-    APM_TEST_PACKAGES: "language-postcss"
+    APM_TEST_PACKAGES: "language-postcss language-vue"
   steps:
     # Restore project state
     - attach_workspace:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   global:
     # Pre-install the required language file as package activation doesn't wait
     # for the installation to complete.
-    - APM_TEST_PACKAGES="language-postcss"
+    - APM_TEST_PACKAGES="language-postcss language-vue"
 
 jobs:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 ### Project specific config ###
 environment:
-  APM_TEST_PACKAGES: language-postcss
+  APM_TEST_PACKAGES: language-postcss language-vue
 
   matrix:
   - ATOM_CHANNEL: stable

--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,8 @@ export default {
       'source.less',
       'source.css.less',
       'source.css.postcss',
-      'source.css.postcss.sugarss'
+      'source.css.postcss.sugarss',
+      'source.css.scss.embedded.html'
     ];
   },
 

--- a/spec/fixtures/vue/.stylelintrc
+++ b/spec/fixtures/vue/.stylelintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "block-no-empty": true
+  }
+}

--- a/spec/fixtures/vue/badSCSS.vue
+++ b/spec/fixtures/vue/badSCSS.vue
@@ -1,0 +1,9 @@
+<template></template>
+
+
+<script></script>
+
+
+<style lang="scss" scoped>
+a {}
+</style>

--- a/spec/fixtures/vue/goodSCSS.vue
+++ b/spec/fixtures/vue/goodSCSS.vue
@@ -1,0 +1,11 @@
+<template></template>
+
+
+<script></script>
+
+
+<style lang="scss" scoped>
+a {
+  color: red;
+}
+</style>

--- a/spec/linter-stylelint-spec.js
+++ b/spec/linter-stylelint-spec.js
@@ -328,4 +328,30 @@ describe('The stylelint provider for Linter', () => {
       rimraf.sync(tempDir);
     });
   });
+
+  describe('works with Vue Single File Components', () => {
+    const goodVueSCSS = path.join(fixtures, 'vue', 'goodSCSS.vue');
+    const badVueSCSS = path.join(fixtures, 'vue', 'badSCSS.vue');
+
+    beforeEach(async () => {
+      await atom.packages.activatePackage('language-vue');
+    });
+
+    it('shows lint messages when found', async () => {
+      const editor = await atom.workspace.open(badVueSCSS);
+      const messages = await lint(editor);
+
+      expect(messages[0].severity).toBe('error');
+      expect(messages[0].excerpt).toBe(blockNoEmpty);
+      expect(messages[0].url).toBe(blockNoEmptyUrl);
+      expect(messages[0].location.file).toBe(badVueSCSS);
+      expect(messages[0].location.position).toEqual([[7, 2], [7, 4]]);
+    });
+
+    it('finds nothing wrong with a valid file', async () => {
+      const editor = await atom.workspace.open(goodVueSCSS);
+      const messages = await lint(editor);
+      expect(messages.length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
This adds the `source.css.scss.embedded.html` scope (used for style tags in vue single page components) in order to enable stylelint linting in `.vue` files.

Fixes #403 
