### PR TITLE
CircleCI cache fixing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,9 +22,6 @@ defaults: &defaults
         name: APM version
         command: ${APM_SCRIPT_PATH} --version
     - run:
-        name: Cleaning package
-        command: ${APM_SCRIPT_PATH} clean
-    - run:
         name: Package APM package dependencies
         command: |
           if [ -n "${APM_TEST_PACKAGES}" ]; then
@@ -35,6 +32,9 @@ defaults: &defaults
     - run:
         name: Package dependencies
         command: ${APM_SCRIPT_PATH} install
+    - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
     - run:
         name: Package specs
         command: ${ATOM_SCRIPT_PATH} --test spec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ defaults: &defaults
     - save_cache:
         paths:
           - node_modules
-        key: v2-dependencies-{{ checksum "package.json" }}
+        key: v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
 
 jobs:
   checkout_code:
@@ -54,10 +54,15 @@ jobs:
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v2-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v2-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v3-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v3-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v3-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp


### PR DESCRIPTION
Previously it was possible for a dependency update in a test branch to "poison" the node_modules cache to a state that might break other builds without a lot of cleanup. Make the branch builds stay within their own branch, only falling back to master if necessary.

Also only run `apm clean` after `apm install` has had a chance to run, in case the uninstall script of a module depends on something that isn't installed.