### PR TITLE
feat: sass linter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,8 @@ export default {
       'source.css',
       'source.scss',
       'source.css.scss',
+      'source.sass',
+      'source.css.sass',
       'source.less',
       'source.css.less',
       'source.css.postcss',

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ an interface to [stylelint](https://github.com/stylelint/stylelint).
 apm install linter-stylelint
 ```
 
-linter-stylelint runs `stylelint` against your CSS, SCSS, Less, PostCSS,
+linter-stylelint runs `stylelint` against your CSS, SCSS, SASS, Less, PostCSS,
 and SugarSS files.
 
 ## Configuration


### PR DESCRIPTION
Updates base scopes to include sass since it's already built into stylelint.  It's working on my local, not sure what other testing was required. Adds note to readme to add sass to the list of lintable languages/extensions.