### PR TITLE
Use local stylelint for config resolution if available

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -168,6 +168,10 @@ export function refreshModulesPath(modulesDir) {
 }
 
 function getProjectDir(filePath) {
+  if (!filePath) {
+    // No file (e.g. in the specs)
+    return null;
+  }
   const projectDir = atom.project.relativizePath(filePath)[0];
   return projectDir !== null ? projectDir : path.dirname(filePath);
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,6 @@ import hasValidScope from './validate';
 // Dependencies
 let helpers;
 let dirname;
-let stylelint;
 
 function loadDeps() {
   if (!helpers) {
@@ -15,9 +14,6 @@ function loadDeps() {
   }
   if (!dirname) {
     ({ dirname } = require('path'));
-  }
-  if (!stylelint) {
-    stylelint = require('stylelint');
   }
 }
 
@@ -156,6 +152,8 @@ export default {
         }
 
         helpers.startMeasure('linter-stylelint: Create Linter');
+        // Use the project local stylelint to resolve the config if one exists
+        const stylelint = await helpers.getStylelintInstance();
         const stylelintLinter = await stylelint.createLinter();
         helpers.endMeasure('linter-stylelint: Create Linter');
 


### PR DESCRIPTION
Although the running of stylelint was changed to use the local project's instance if available in #381, the instance used to determine the configuration was unfortunately left as the bundled version. This made no difference then, and made no difference when the bundled version was still compatible with the local project one... but caused issues when there is a mismatch.

This fixes it so we always use the stylelint instance local to the project if there is one available, falling back to the bundled one if one isn't available.

Fixes #440.
Closes #441.