### PR TITLE
Update helpers.js

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,12 +84,24 @@ const parseResults = (editor, results, filePath, showIgnored) => {
     } else {
       // Plugin rule
       const pluginName = ruleParts[0];
-      // const ruleName = ruleParts[1];
+      const ruleName = ruleParts[1];
 
       const linterStylelintURL = 'https://github.com/AtomLinter/linter-stylelint/tree/master/docs';
       switch (pluginName) {
         case 'plugin':
           message.url = `${linterStylelintURL}/noRuleNamespace.md`;
+          break;
+        case 'scss':
+          message.url = `https://github.com/kristerkari/stylelint-scss/blob/master/src/rules/${ruleName}/README.md`;
+          break;
+        case 'csstools':
+          message.url = `https://github.com/csstools/stylelint-${ruleName}/blob/master/README.md`;
+          break;
+        case 'color-format':
+          message.url = 'https://github.com/filipekiss/stylelint-color-format/blob/master/README.md';
+          break;
+        case 'scale-unlimited':
+          message.url = 'https://github.com/AndyOGo/stylelint-declaration-strict-value/blob/master/README.md';
           break;
         default:
           message.url = `${linterStylelintURL}/linkingNewRule.md`;


### PR DESCRIPTION
Added message url for scss plugin, plugins from csstools, color-format plugin and scale-unlimited plugin.

`scss` is a plugin with multiple rules, so `ruleName` is used to access the correct readme file.
`csstools` offers 4 plugins which are installed separately. All 4 plugins are under same namespace but since naming scheme is same for all 4 plugins `ruleName` can be used to access the correct repository.
`color-format` and `scale-unlimited` are plugins with just a single rule, so the name of plugin itself is sufficient to set url.