### PR TITLE
docs: move badges out of the title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,6 @@
-# linter-stylelint [![Dependency Status](https://david-dm.org/AtomLinter/linter-stylelint.svg)](https://david-dm.org/AtomLinter/linter-stylelint) [![Greenkeeper badge](https://badges.greenkeeper.io/AtomLinter/linter-stylelint.svg)](https://greenkeeper.io/)
+# linter-stylelint
+
+[![Dependency Status](https://david-dm.org/AtomLinter/linter-stylelint.svg)](https://david-dm.org/AtomLinter/linter-stylelint) [![Greenkeeper badge](https://badges.greenkeeper.io/AtomLinter/linter-stylelint.svg)](https://greenkeeper.io/)
 
 A plugin for [Atom Linter](https://github.com/AtomLinter/atom-linter) providing
 an interface to [stylelint](https://github.com/stylelint/stylelint).


### PR DESCRIPTION
Title formatting is messed up because the badges are on the same line. This affects GitHub, atom.io ([screenshot](https://user-images.githubusercontent.com/22385371/151610744-fa590190-bc9c-4b43-86fd-09dbb88c7aa1.png)), and Atom itself ([screenshot](https://user-images.githubusercontent.com/22385371/151611063-36e26c3f-493a-4b52-ba02-0a8cab34d5f2.png)).

Before, on GitHub:
![image](https://user-images.githubusercontent.com/22385371/151610806-4dacf206-d6c4-4169-83a7-cae055d077a5.png)

After, on GitHub:
![image](https://user-images.githubusercontent.com/22385371/151610970-76c128cd-379e-4558-9cd4-0b30f1a47dcf.png)