### PR TITLE
Clarify settings verbiage

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "configSchema": {
     "useStandard": {
-      "title": "Use standard",
+      "title": "Use standard config",
       "description": "Use the stylelint-config-standard lint configuration when no other configuration is found. Disables the \"Disable when no config\" option.",
       "type": "boolean",
       "default": false


### PR DESCRIPTION
"Use standard" -> "Use standard config".

This is a minor change, but it's to avoid confusion like I just had.